### PR TITLE
Optional scheduler for output streams

### DIFF
--- a/packages/mutator-io/src/output-stream.ts
+++ b/packages/mutator-io/src/output-stream.ts
@@ -1,7 +1,8 @@
 import { Observable } from 'rxjs'
+import { IScheduler } from 'rxjs/Scheduler'
 
 export interface OutputStreamCreateMethod {
-  (msg: Object): Observable<any>
+  (msg: Object, scheduler ?: IScheduler): Observable<any>
 }
 
 export interface OutputStream {


### PR DESCRIPTION
This adds an optional parameter so we can provide our own scheduler (e.g. `TestScheduler`) to test more complex time-sensitive flows