### PR TITLE
Allow generic types for input/transform/output streams

### DIFF
--- a/packages/mutator-io-plugin-out-dynamodb/index.ts
+++ b/packages/mutator-io-plugin-out-dynamodb/index.ts
@@ -8,7 +8,7 @@ declare global {
   }
 }
 
-class DynamoDB implements OutputStream {
+class DynamoDB implements OutputStream<DynamoDB.Message> {
   client: AwsDynamoDB.DocumentClient
 
   constructor(config: DynamoDB.Config = {}) {

--- a/packages/mutator-io/package.json
+++ b/packages/mutator-io/package.json
@@ -32,7 +32,6 @@
   "dependencies": {
     "colors": "^1.1.2",
     "rxjs": "5.4.2",
-    "typedoc-plugin-markdown": "^1.0.11",
     "uuid": "^3.1.0",
     "winston": "^2.3.1"
   },
@@ -46,6 +45,7 @@
     "proxyquire": "^1.8.0",
     "sinon": "^2.3.8",
     "typedoc": "^0.9.0",
+    "typedoc-plugin-markdown": "^1.0.11",
     "typescript": "^2.5.3"
   },
   "directories": {

--- a/packages/mutator-io/src/input-stream.ts
+++ b/packages/mutator-io/src/input-stream.ts
@@ -1,5 +1,5 @@
 import { Observable } from 'rxjs'
 
 export interface InputStream<T> {
-  create(): Observable<T>
+  create(): Observable<T> | Promise<T> | T
 }

--- a/packages/mutator-io/src/mutator-io.ts
+++ b/packages/mutator-io/src/mutator-io.ts
@@ -7,9 +7,9 @@ import { Subscription } from './subscription'
 import * as shared from './shared'
 import logger from './logger'
 
-interface pipeResult extends Array<Object> {
+interface pipeResult extends Array<any> {
   0: string
-  1: Observable<Object>
+  1: Observable<any>
   2: Subscription
 }
 
@@ -42,7 +42,7 @@ class MutatorIO {
     return true
   }
 
-  transform(pipeName: string, transform: TransformStream): Subscription {
+  transform(pipeName: string, transform: TransformStream<any>): Subscription {
     this.transformers[pipeName] = this.transformers[pipeName] || []
     const lastIndex = this.transformers[pipeName].push(transform) - 1
 
@@ -54,14 +54,15 @@ class MutatorIO {
 
   private composeStream(
     pipe: MutatorIO.Pipe,
-    transformer: TransformStream
+    transformer: TransformStream<any>
   ): pipeResult {
     const inStream = pipe.in.create()
     const outStream = pipe.out.create()
 
     return [
       pipe.name,
-      inStream
+      shared
+        .wrapToObservable(inStream)
         .do(msg => logger.debug(c.yellow('pre-transformation'), msg))
         .flatMap(msg => shared.wrapToObservable(transformer.call(this, msg)))
         .do(msg => logger.debug(c.yellow('post-transformation'), msg))
@@ -114,11 +115,11 @@ namespace MutatorIO {
   export interface Pipe {
     name: string
     in: InputStream<any>
-    out: OutputStream
+    out: OutputStream<any>
   }
 
   export interface Transformers {
-    [name: string]: Array<TransformStream>
+    [name: string]: Array<TransformStream<any>>
   }
 
   export interface Subscriptions {

--- a/packages/mutator-io/src/output-stream.ts
+++ b/packages/mutator-io/src/output-stream.ts
@@ -1,10 +1,10 @@
 import { Observable } from 'rxjs'
 import { IScheduler } from 'rxjs/Scheduler'
 
-export interface OutputStreamCreateMethod {
-  (msg: Object, scheduler?: IScheduler): Observable<any>
+export interface OutputStreamCreateMethod<T> {
+  (msg: T, scheduler?: IScheduler): any
 }
 
-export interface OutputStream {
-  create(): OutputStreamCreateMethod
+export interface OutputStream<T> {
+  create(): OutputStreamCreateMethod<T>
 }

--- a/packages/mutator-io/src/transform-stream.ts
+++ b/packages/mutator-io/src/transform-stream.ts
@@ -1,6 +1,6 @@
 import { Observable } from 'rxjs'
 
-export interface TransformStream {
-  (message: Object): any
+export interface TransformStream<T> {
+  (message: any): Observable<T> | Promise<T> | T
   subscriptionId?: string
 }


### PR DESCRIPTION
This PR:

- Allows InputStreams and OutputStreams to return a single value, a Promise or an Observable (just like TransformStreams )
- Introduces generics for every type of stream:
  - `TransformStream` now requires a type, which will represent the type of data returned
  - `OutputStream` now requires a type, which will represent the type of data that should come in

They can still both be used with `<any>`, but they are meant to add a better layer of checks when writing classes / methods that extends them