### PR TITLE
Simplified MQTT connections

### DIFF
--- a/packages/mutator-io-plugin-in-mqtt/index.ts
+++ b/packages/mutator-io-plugin-in-mqtt/index.ts
@@ -5,64 +5,41 @@ import { InputStream } from 'mutator-io'
 
 class Mqtt implements InputStream<Mqtt.Message> {
   client: mqtt.MqttClient
-  clientObs: Observable<mqtt.MqttClient>
-  topics: string[]
 
   constructor(config: Mqtt.Config) {
     const { topics, ...opts } = config
-    this.topics = topics
-    this.clientObs = Observable.create((observer: Observer<any>) => {
-      if (this.client) {
-        return observer.next(this.client)
-      }
-      this.client = mqtt.connect(opts)
-      this.client.on('connect', () => {
-        observer.next(this.client)
-      })
-      this.client.on('error', e => {
-        observer.error(e)
-      })
-      // TODO: Fix these cases and handle them in test coverage
-      this.client.on('close', e => {
-        console.log('close')
-      })
-      this.client.on('offline', e => {
-        console.log('offline')
-      })
-      this.client.on('reconnect', e => {
-        console.log('reconnect')
-      })
+    this.client = mqtt.connect(opts)
+    this.client.subscribe(topics)
+
+    // TODO: Fix these cases and handle them in test coverage
+    this.client.on('connect', e => {
+      console.log('connect')
+    })
+    this.client.on('error', e => {
+      console.error(e)
+    })
+    this.client.on('close', e => {
+      console.log('close')
+    })
+    this.client.on('offline', e => {
+      console.log('offline')
+    })
+    this.client.on('reconnect', e => {
+      console.log('reconnect')
     })
   }
 
   create() {
-    return this.clientObs.flatMap(client => {
-      const observables = this.topics.map((topic): Observable<any> => {
-        return Observable.create((observer: Observer<Object>) => {
-          client.subscribe(topic, err => {
-            err ? observer.error(err) : observer.next({})
-            observer.complete()
-          })
-        })
-      })
-      return Observable.forkJoin(observables).flatMap((): Observable<any> => {
-        return Observable.create((observer: Observer<Mqtt.Message>) => {
-          let callback = (topic, payload) => {
-            // TODO: Pipe buffer payload into a more performant JSON parser
-            let parsedPayload = payload.toString()
-            try {
-              parsedPayload = JSON.parse(parsedPayload)
-            } catch (e) {}
-            observer.next({ topic, payload: parsedPayload })
-          }
-
-          client.on('message', callback)
-          return () => {
-            client.removeListener('message', callback)
-            callback = null
-          }
-        })
-      })
+    return Observable.fromEvent(this.client, 'message', (topic, payload) => ({
+      topic,
+      payload
+    })).map(({ topic, payload }) => {
+      // TODO: Pipe buffer payload into a more performant JSON parser
+      let parsedPayload = payload.toString()
+      try {
+        parsedPayload = JSON.parse(parsedPayload)
+      } catch (e) {}
+      return { topic, payload: parsedPayload }
     })
   }
 }

--- a/packages/mutator-io-plugin-in-mqtt/test.ts
+++ b/packages/mutator-io-plugin-in-mqtt/test.ts
@@ -30,17 +30,10 @@ describe('Input - Mqtt', () => {
     } as Mqtt.Config)
   })
 
-  it('starts the stream and subscribes to topics when the client connects', () => {
-    mqttInstance.create().subscribe()
-
-    assert(!subscribeSpy.called)
-
-    MqttClientEventEmitter.emit('connect')
-
+  it('starts the stream and subscribes to topics during client initialization', () => {
     assert(subscribeSpy.called)
-    assert(subscribeSpy.getCalls().length === 2)
-    assert(subscribeSpy.getCall(0).args[0] === exampleTopics[0])
-    assert(subscribeSpy.getCall(0).args[1] instanceof Function)
+    assert.equal(subscribeSpy.getCalls().length, 1)
+    assert.equal(subscribeSpy.getCall(0).args[0], exampleTopics)
   })
 
   it('pipes the mqtt client messages out of the stream when the client connects', done => {
@@ -53,19 +46,6 @@ describe('Input - Mqtt', () => {
     mqttInstance
       .create()
       .subscribe(...global.baseSubscriber(expectedValue, done))
-
-    assert(!subscribeSpy.called)
-
-    MqttClientEventEmitter.emit('connect')
-
-    assert(subscribeSpy.called)
-    assert(subscribeSpy.getCalls().length === 2)
-
-    const callback1 = subscribeSpy.getCall(0).args[1]
-    const callback2 = subscribeSpy.getCall(1).args[1]
-    // We need to call both callbacks to make forJoin happy
-    callback1()
-    callback2()
 
     MqttClientEventEmitter.emit(
       'message',
@@ -84,19 +64,6 @@ describe('Input - Mqtt', () => {
     mqttInstance
       .create()
       .subscribe(...global.baseSubscriber(expectedValue, done))
-
-    assert(!subscribeSpy.called)
-
-    MqttClientEventEmitter.emit('connect')
-
-    assert(subscribeSpy.called)
-    assert(subscribeSpy.getCalls().length === 2)
-
-    const callback1 = subscribeSpy.getCall(0).args[1]
-    const callback2 = subscribeSpy.getCall(1).args[1]
-    // We need to call both callbacks to make forJoin happy
-    callback1()
-    callback2()
 
     MqttClientEventEmitter.emit(
       'message',
@@ -129,19 +96,6 @@ describe('Input - Mqtt', () => {
       e => done(new Error(e))
     )
 
-    assert(!subscribeSpy.called)
-
-    MqttClientEventEmitter.emit('connect')
-
-    assert(subscribeSpy.called)
-    assert(subscribeSpy.getCalls().length === 2)
-
-    const callback1 = subscribeSpy.getCall(0).args[1]
-    const callback2 = subscribeSpy.getCall(1).args[1]
-    // We need to call both callbacks to make forJoin happy
-    callback1()
-    callback2()
-
     MqttClientEventEmitter.emit(
       'message',
       exampleTopics[0],
@@ -153,41 +107,5 @@ describe('Input - Mqtt', () => {
       exampleTopics[0],
       JSON.stringify(exampleValue)
     )
-  })
-
-  describe('Error handling', () => {
-    it('outputs an error in the error stream callback when the client cannot connect', done => {
-      const errorMsg = 'my error'
-      mqttInstance.create().subscribe(
-        () => {},
-        err => {
-          assert(err === errorMsg)
-          done()
-        }
-      )
-
-      assert(!subscribeSpy.called)
-      MqttClientEventEmitter.emit('error', errorMsg)
-      assert(!subscribeSpy.called)
-    })
-
-    it('outputs an error in the error stream callback when the client cannot subscribe', done => {
-      const errorMsg = 'my subscribe error'
-      mqttInstance.create().subscribe(
-        () => {},
-        err => {
-          assert(err === errorMsg)
-          done()
-        }
-      )
-
-      assert(!subscribeSpy.called)
-      MqttClientEventEmitter.emit('connect')
-      assert(subscribeSpy.called)
-      assert(subscribeSpy.getCalls().length === 2)
-
-      const callback = subscribeSpy.getCall(0).args[1]
-      callback(errorMsg)
-    })
   })
 })


### PR DESCRIPTION
* Have only one MQTT client for one input stream.
* Let MQTT.js handle reconnection and resubscription.
* Prefer using Observable.fromEvent.